### PR TITLE
Bootup:Code:MaaXBoard-Mini: Modified to support bootup for MaaXBoard-…

### DIFF
--- a/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
@@ -69,8 +69,10 @@ static const struct imx_rdc_cfg rdc[] = {
 	RDC_MDAn(RDC_MDA_M4, DID1),
 
 	/* peripherals domain permission */
+#if 0
 	RDC_PDAPn(RDC_PDAP_UART4, D1R | D1W),
 	RDC_PDAPn(RDC_PDAP_UART2, D0R | D0W),
+#endif
 	RDC_PDAPn(RDC_PDAP_UART1, D0R | D0W),
 
 	/* memory region */
@@ -116,8 +118,10 @@ static const struct imx_rdc_cfg rdc[] = {
 	RDC_MDAn(RDC_MDA_M4, DID1),
 
 	/* peripherals domain permission */
+#if 0
 	RDC_PDAPn(RDC_PDAP_UART4, D1R | D1W),
 	RDC_PDAPn(RDC_PDAP_UART2, D0R | D0W),
+#endif
 	RDC_PDAPn(RDC_PDAP_UART1, D0R | D0W),
 
 	/* memory region */

--- a/plat/imx/imx8m/imx8mm/platform.mk
+++ b/plat/imx/imx8m/imx8mm/platform.mk
@@ -158,7 +158,7 @@ $(eval $(call add_define,BL32_BASE))
 BL32_SIZE		?=	0x2000000
 $(eval $(call add_define,BL32_SIZE))
 
-IMX_BOOT_UART_BASE	?=	0x30890000
+IMX_BOOT_UART_BASE	=	0x30860000
 $(eval $(call add_define,IMX_BOOT_UART_BASE))
 
 EL3_EXCEPTION_HANDLING := $(SDEI_SUPPORT)


### PR DESCRIPTION
…Mini

    1, change the console UART_BASE to UART1, or u-boot can not bootup
    2, disable UART2 and UART4 in Cortex-M core